### PR TITLE
Use hashed input args in cache key (not it's text directly)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,18 @@ runs:
         echo "poetry-version=$version" >> $GITHUB_OUTPUT
         echo "::endgroup::"
 
+    # Poetry install arguments may contain some special symbols (most notably a comma), which can't be
+    # present in cache keys. Compute a hash of the input arguments which we can safely use instead
+    - name: Hash install arguments
+      shell: bash
+      id: install_args_hash
+      run: |
+        echo "::group::Hash poetry install arguments"
+        echo "Passed install args: ${{ inputs.install-args }}"
+        hashed_args=$(echo -n "${{ inputs.install-args }}" | sha256sum | cut -d" " -f1)
+        echo "Resulting hash: $hashed_args"
+        echo "install-args-hash=$hashed_args" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
 
     - name: Cache poetry installation
       # We're using the cache restore only action, rather than full actions/cache, as we then explicitly
@@ -241,14 +253,14 @@ runs:
               os-${{ runner.os }}--\
               python-${{ steps.python_setup.outputs.python-version }}--\
               poetry-${{ steps.installed_poetry_version.outputs.poetry-version }}--\
-              args-${{ inputs.install-args }}--\
+              args-${{ steps.install_args_hash.outputs.install-args-hash }}--\
               workdir-${{ inputs.working-dir }}--\
               filehash-${{ hashFiles(format('{0}/pyproject.toml', inputs.working-dir), format('{0}/poetry.lock', inputs.working-dir)) }}"
         restore-keys: "setup-poetry-v1.0.0--cache-dependencies--\
                         os-${{ runner.os }}--\
                         python-${{ steps.python_setup.outputs.python-version }}--\
                         poetry-${{ steps.installed_poetry_version.outputs.poetry-version }}--\
-                        args-${{ inputs.install-args }}--\
+                        args-${{ steps.install_args_hash.outputs.install-args-hash }}--\
                         workdir-${{ inputs.working-dir }}--"
 
     - name: Create poetry environment for the project


### PR DESCRIPTION
Input args are controlled by the user, and could potentially contain anything. A common occurence is for example `--only group1,group2`. In this example, the args contain a comma character, which is however not allowed to be present in a cache key.

To solve this issue, rather than using the input arguments directly as a part of the cache key, construct a sha256 hash of them and use it instead.

This hash should not contain any prohibited characters, as it's output is in base64 (0-9, a-f), all of which are allowed to be a part of the cache key.

Closes #2 